### PR TITLE
Ducktype the call

### DIFF
--- a/src/ModelTES.jl
+++ b/src/ModelTES.jl
@@ -309,14 +309,14 @@ end
 
 
 "Calling a BiasedTES gives the dI and dT terms for integration in an in place manner."
-function (bt::BiasedTES){S<:Float64}(t::Float64, u::AbstractVector{S}, du::AbstractVector{S})
+function (bt::BiasedTES){S}(t, u::AbstractVector{S}, du::AbstractVector{S})
     T,I = u[1],u[2]
     p = bt.p
     r = R(I,T,p)
     # dT(I, T, p.k, p.n, p.Tbath, p.C, r)
     # dI(I,T, bt.V, p.Rl, p.L, r)
-    du[:] = [dT(I, T, p.k, p.n, p.Tbath, p.C, r),
-             dI(I,T, bt.V, p.Rl, p.L, r)]
+    du[1] = dT(I, T, p.k, p.n, p.Tbath, p.C, r)
+    du[2] = dI(I,T, bt.V, p.Rl, p.L, r)
 end
 
 function rk8(nsample::Int, dt::Float64, bt::BiasedTES, E::Vector, npresamples::Int=0)


### PR DESCRIPTION
This improves the `tes(t,u,du)` call, reducing an allocation. More importantly, it gets rid of the `<:Float64`. Note that type check did not help performance at all (Julia will automatically specialize functions on the types given), but restricted where the function could be used. Specifically, by taking off the `Float64` requirement, this now works with autodifferentiation and thus with the stiff solver `Rosenbrock23()`. 